### PR TITLE
Fix erroneous expansion inside run scripts

### DIFF
--- a/dafnyportfolio/src/job_creation/make_cloud_job.py
+++ b/dafnyportfolio/src/job_creation/make_cloud_job.py
@@ -91,7 +91,7 @@ def make_sbatch_prefix_args(args, output_filename, runtime=None, mem=None):
 
 
 def make_sbatch_prefix_string(cmd_args):
-    cmd = "sbatch << EOF\n#!/bin/sh\n"
+    cmd = "sbatch << 'EOF'\n#!/bin/sh\n"
     for arg in cmd_args:
         cmd += f"#SBATCH {arg}\n"
     return cmd


### PR DESCRIPTION
Heredoc inputs are expanded unless the delimiter is in quotation marks.
This causes procedure names to be altered (through expansion) before passed to Dafny.
This pull request adds quotation marks to delimiters where appropriate